### PR TITLE
1. Input size limit. 2. Generate alignments with words along with indices

### DIFF
--- a/run_align.py
+++ b/run_align.py
@@ -107,6 +107,24 @@ def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
                     writer.write(' '.join(output_str)+'\n')
                 tqdm_iterator.update(len(ids_src))
 
+    with open(args.output_file, 'r') as fh:
+        outputf = (fh.read()).split("\n")
+    with open(args.data_file, 'r') as fh:
+        datalines = (fh.read()).split("\n")
+
+    with open(args.output_file+".outtxt", 'w') as fwriter:
+        for indices, line in zip(outputf, datalines):
+            srcline, tgtline = line.split(' ||| ')
+            indices = indices.split()
+            srcwrds = srcline.split()
+            tgtwrds = tgtline.split()
+            output_wrds = []
+            for wrd in indices:
+                srcix,tgtix = wrd.split("-")
+                srcix, tgtix = int(srcix), int(tgtix)
+                output_wrds.append(f"{srcwrds[srcix]}-{tgtwrds[tgtix]}")
+            fwriter.write(' '.join(output_wrds)+'\n')
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/run_align.py
+++ b/run_align.py
@@ -125,7 +125,6 @@ def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
                 output_wrds.append(f"{srcwrds[srcix]}-{tgtwrds[tgtix]}")
             fwriter.write(' '.join(output_wrds)+'\n')
 
-
 def main():
     parser = argparse.ArgumentParser()
 

--- a/run_align.py
+++ b/run_align.py
@@ -78,8 +78,7 @@ class LineByLineTextDataset(Dataset):
     def __getitem__(self, i):
         return self.examples[i]
 
-def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
-
+def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, output_word_alignments = False):
     def collate(examples):
         ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt = zip(*examples)
         ids_src = pad_sequence(ids_src, batch_first=True, padding_value=tokenizer.pad_token_id)
@@ -107,23 +106,24 @@ def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
                     writer.write(' '.join(output_str)+'\n')
                 tqdm_iterator.update(len(ids_src))
 
-    with open(args.output_file, 'r') as fh:
-        outputf = (fh.read()).split("\n")
-    with open(args.data_file, 'r') as fh:
-        datalines = (fh.read()).split("\n")
+    if output_word_alignments:
+        with open(args.output_file, 'r') as fh:
+            outputf = (fh.read()).split("\n")
+        with open(args.data_file, 'r') as fh:
+            datalines = (fh.read()).split("\n")
 
-    with open(args.output_file+".outtxt", 'w') as fwriter:
-        for indices, line in zip(outputf, datalines):
-            srcline, tgtline = line.split(' ||| ')
-            indices = indices.split()
-            srcwrds = srcline.split()
-            tgtwrds = tgtline.split()
-            output_wrds = []
-            for wrd in indices:
-                srcix,tgtix = wrd.split("-")
-                srcix, tgtix = int(srcix), int(tgtix)
-                output_wrds.append(f"{srcwrds[srcix]}-{tgtwrds[tgtix]}")
-            fwriter.write(' '.join(output_wrds)+'\n')
+        with open(args.output_file+".outtxt", 'w') as fwriter:
+            for indices, line in zip(outputf, datalines):
+                srcline, tgtline = line.split(' ||| ')
+                indices = indices.split()
+                srcwrds = srcline.split()
+                tgtwrds = tgtline.split()
+                output_wrds = []
+                for wrd in indices:
+                    srcix,tgtix = wrd.split("-")
+                    srcix, tgtix = int(srcix), int(tgtix)
+                    output_wrds.append(f"{srcwrds[srcix]}-{tgtwrds[tgtix]}")
+                fwriter.write(' '.join(output_wrds)+'\n')
 
 def main():
     parser = argparse.ArgumentParser()

--- a/run_train.py
+++ b/run_train.py
@@ -711,9 +711,9 @@ def main():
 
     # Setup CUDA, GPU & distributed training
     if args.spc_gpu ==1: 
-    device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
-    torch.cuda.set_device(args.local_rank)
-    args.n_gpu = 1
+        device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+        torch.cuda.set_device(args.local_rank)
+        args.n_gpu = 1
 
     elif args.local_rank == -1 or args.no_cuda:
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")

--- a/run_train.py
+++ b/run_train.py
@@ -713,7 +713,7 @@ def main():
     if args.spc_gpu ==1: 
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
         torch.cuda.set_device(args.local_rank)
-        torch.distributed.init_process_group(backend="nccl", rank=args.local_rank)
+        torch.distributed.init_process_group(backend="nccl", rank=args.local_rank, world_size=1)
         args.n_gpu = 1
 
     elif args.local_rank == -1 or args.no_cuda:

--- a/run_train.py
+++ b/run_train.py
@@ -710,18 +710,18 @@ def main():
         )
 
     # Setup CUDA, GPU & distributed training
-    if args.local_rank == -1 or args.no_cuda:
+    if args.spc_gpu ==1: 
+    device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+    torch.cuda.set_device(args.local_rank)
+    args.n_gpu = 1
+
+    elif args.local_rank == -1 or args.no_cuda:
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
         args.n_gpu = 0 if args.no_cuda else torch.cuda.device_count()
     else:  # Initializes the distributed backend which will take care of sychronizing nodes/GPUs
         torch.cuda.set_device(args.local_rank)
         device = torch.device("cuda", args.local_rank)
         torch.distributed.init_process_group(backend="nccl")
-        args.n_gpu = 1
-    
-    if args.spc_gpu ==1: 
-        device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
-        torch.cuda.set_device(args.local_rank)
         args.n_gpu = 1
 
 

--- a/run_train.py
+++ b/run_train.py
@@ -72,6 +72,9 @@ class LineByLineTextDataset(Dataset):
 
                         ids_src, ids_tgt = tokenizer.prepare_for_model(list(itertools.chain(*wid_src)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids'], tokenizer.prepare_for_model(list(itertools.chain(*wid_tgt)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids']
 
+                        if len(ids_src[0]) + len(ids_tgt[0]) >= args.max_position_embeddings:
+                            continue
+
                         bpe2word_map_src = []
                         for i, word_list in enumerate(token_src):
                             bpe2word_map_src += [i for x in word_list]
@@ -79,10 +82,6 @@ class LineByLineTextDataset(Dataset):
                         for i, word_list in enumerate(token_tgt):
                             bpe2word_map_tgt += [i for x in word_list]
 
-                        if len(ids_src[0]) + len(ids_tgt[0]) >= args.max_position_embeddings: 
-                            print(f"IDs Src length is {len(ids_src[0])} && {len(ids_tgt[0])}")
-                            print(f"IDs are {ids_src} & {ids_src[0]}")
-                            continue
 
                         self.examples.append( (ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt) )
 

--- a/run_train.py
+++ b/run_train.py
@@ -713,6 +713,7 @@ def main():
     if args.spc_gpu ==1: 
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
         torch.cuda.set_device(args.local_rank)
+        torch.distributed.init_process_group(backend="nccl", rank=args.local_rank)
         args.n_gpu = 1
 
     elif args.local_rank == -1 or args.no_cuda:

--- a/run_train.py
+++ b/run_train.py
@@ -713,7 +713,7 @@ def main():
     if args.spc_gpu ==1: 
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
         torch.cuda.set_device(args.local_rank)
-        torch.distributed.init_process_group(backend="nccl", rank=args.local_rank, world_size=1)
+        torch.distributed.init_process_group(backend="nccl")
         args.n_gpu = 1
 
     elif args.local_rank == -1 or args.no_cuda:

--- a/run_train.py
+++ b/run_train.py
@@ -228,7 +228,10 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
         langid_tgtsrc = pad_sequence(langid_tgtsrc, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
-        guides = model.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
+
+        model_distr = model.module if isinstance(model, DataParallel) else model  # Take care of distributed/parallel training
+
+        guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels
 
 
@@ -469,7 +472,10 @@ def evaluate(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prefi
         langid_tgtsrc = pad_sequence(langid_tgtsrc, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
-        guides = model.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
+        
+        model_distr = model.module if isinstance(model, DataParallel) else model  # Take care of distributed/parallel training
+
+        guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels
 
     eval_sampler = SequentialSampler(eval_dataset)

--- a/run_train.py
+++ b/run_train.py
@@ -685,6 +685,7 @@ def main():
     args = parser.parse_args()
 
     os.environ["CUDA_VISIBLE_DEVICES"]=args.local_rank
+    args.local_rank = 0
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(

--- a/run_train.py
+++ b/run_train.py
@@ -684,7 +684,7 @@ def main():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
     args = parser.parse_args()
 
-    os.environ["CUDA_VISIBLE_DEVICES"]=1
+    os.environ["CUDA_VISIBLE_DEVICES"]="1"
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(

--- a/run_train.py
+++ b/run_train.py
@@ -684,7 +684,7 @@ def main():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
     args = parser.parse_args()
 
-    os.environ["CUDA_VISIBLE_DEVICES"]=args.local_rank
+    os.environ["CUDA_VISIBLE_DEVICES"]=str(args.local_rank)
     args.local_rank = 0
 
     if args.eval_data_file is None and args.do_eval:

--- a/run_train.py
+++ b/run_train.py
@@ -712,8 +712,6 @@ def main():
     # Setup CUDA, GPU & distributed training
     if args.spc_gpu ==1: 
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
-        torch.cuda.set_device(args.local_rank)
-        torch.distributed.init_process_group(backend="nccl")
         args.n_gpu = 1
 
     elif args.local_rank == -1 or args.no_cuda:

--- a/run_train.py
+++ b/run_train.py
@@ -661,6 +661,7 @@ def main():
         help="Limit the total amount of checkpoints, delete the older checkpoints in the output_dir, does not delete by default",
     )
     parser.add_argument("--no_cuda", action="store_true", help="Avoid using CUDA when available")
+    parser.add_argument("--spc_gpu", default=1, type=int, help="No of GPUs to use")
     parser.add_argument(
         "--overwrite_output_dir", action="store_true", help="Overwrite the content of the output directory"
     )
@@ -717,6 +718,12 @@ def main():
         device = torch.device("cuda", args.local_rank)
         torch.distributed.init_process_group(backend="nccl")
         args.n_gpu = 1
+    
+    if args.spc_gpu ==1: 
+        device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+        args.n_gpu = 1
+
+
     args.device = device
 
     # Setup logging

--- a/run_train.py
+++ b/run_train.py
@@ -684,8 +684,7 @@ def main():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
     args = parser.parse_args()
 
-    os.environ["CUDA_VISIBLE_DEVICES"]=str(args.local_rank)
-    args.local_rank = 0
+    os.environ["CUDA_VISIBLE_DEVICES"]=1
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(

--- a/run_train.py
+++ b/run_train.py
@@ -661,7 +661,6 @@ def main():
         help="Limit the total amount of checkpoints, delete the older checkpoints in the output_dir, does not delete by default",
     )
     parser.add_argument("--no_cuda", action="store_true", help="Avoid using CUDA when available")
-    parser.add_argument("--spc_gpu", default=1, type=int, help="No of GPUs to use")
     parser.add_argument(
         "--overwrite_output_dir", action="store_true", help="Overwrite the content of the output directory"
     )
@@ -682,10 +681,7 @@ def main():
         "See details at https://nvidia.github.io/apex/amp.html",
     )
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
-    parser.add_argument("--gpu_rank", type=int, default=1, help="Select GPU to train")
     args = parser.parse_args()
-
-    os.environ["CUDA_VISIBLE_DEVICES"]=str(args.gpu_rank)
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(
@@ -712,11 +708,7 @@ def main():
         )
 
     # Setup CUDA, GPU & distributed training
-    if args.spc_gpu ==1: 
-        device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
-        args.n_gpu = 1
-
-    elif args.local_rank == -1 or args.no_cuda:
+    if args.local_rank == -1 or args.no_cuda:
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
         args.n_gpu = 0 if args.no_cuda else torch.cuda.device_count()
     else:  # Initializes the distributed backend which will take care of sychronizing nodes/GPUs
@@ -724,8 +716,6 @@ def main():
         device = torch.device("cuda", args.local_rank)
         torch.distributed.init_process_group(backend="nccl")
         args.n_gpu = 1
-
-
     args.device = device
 
     # Setup logging

--- a/run_train.py
+++ b/run_train.py
@@ -72,9 +72,6 @@ class LineByLineTextDataset(Dataset):
 
                         ids_src, ids_tgt = tokenizer.prepare_for_model(list(itertools.chain(*wid_src)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids'], tokenizer.prepare_for_model(list(itertools.chain(*wid_tgt)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids']
 
-                        if len(ids_src[0]) + len(ids_tgt[0]) >= args.max_position_embeddings:
-                            continue
-
                         bpe2word_map_src = []
                         for i, word_list in enumerate(token_src):
                             bpe2word_map_src += [i for x in word_list]
@@ -749,8 +746,6 @@ def main():
     else:
         config = config_class()
 
-    args.max_position_embeddings = config.max_position_embeddings
-
     if args.tokenizer_name:
         tokenizer = tokenizer_class.from_pretrained(args.tokenizer_name, cache_dir=args.cache_dir)
     elif args.model_name_or_path:
@@ -766,10 +761,10 @@ def main():
     modeling.SEP_ID = tokenizer.sep_token_id
 
     if args.block_size <= 0:
-        args.block_size = tokenizer.max_len
+        args.block_size = config.max_position_embeddings
         # Our input block size will be the max possible for the model
     else:
-        args.block_size = min(args.block_size, tokenizer.max_len)
+        args.block_size = min(args.block_size, config.max_position_embeddings)
 
     if args.model_name_or_path:
         model = model_class.from_pretrained(

--- a/run_train.py
+++ b/run_train.py
@@ -684,6 +684,7 @@ def main():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
     args = parser.parse_args()
 
+    os.environ["CUDA_VISIBLE_DEVICES"]=args.local_rank
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(

--- a/run_train.py
+++ b/run_train.py
@@ -721,6 +721,7 @@ def main():
     
     if args.spc_gpu ==1: 
         device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+        torch.cuda.set_device(args.local_rank)
         args.n_gpu = 1
 
 

--- a/run_train.py
+++ b/run_train.py
@@ -229,7 +229,7 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
 
-        model_distr = model.module if isinstance(model, DataParallel) else model  # Take care of distributed/parallel training
+        model_distr = model.module if isinstance(model, torch.nn.DataParallel) else model  # Take care of distributed/parallel training
 
         guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels
@@ -473,7 +473,7 @@ def evaluate(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prefi
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
         
-        model_distr = model.module if isinstance(model, DataParallel) else model  # Take care of distributed/parallel training
+        model_distr = model.module if isinstance(model, torch.nn.DataParallel) else model  # Take care of distributed/parallel training
 
         guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels

--- a/run_train.py
+++ b/run_train.py
@@ -79,6 +79,11 @@ class LineByLineTextDataset(Dataset):
                         for i, word_list in enumerate(token_tgt):
                             bpe2word_map_tgt += [i for x in word_list]
 
+                        if len(ids_src[0]) + len(ids_tgt[0]) >= args.max_position_embeddings: 
+                            print(f"IDs Src length is {len(ids_src[0])} && {len(ids_tgt[0])}")
+                            print(f"IDs are {ids_src} & {ids_src[0]}")
+                            continue
+
                         self.examples.append( (ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt) )
 
             if args.cache_data:
@@ -673,6 +678,7 @@ def main():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
     args = parser.parse_args()
 
+
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(
             "Cannot do evaluation without an evaluation data file. Either supply a file to --eval_data_file "
@@ -738,6 +744,8 @@ def main():
         config = config_class.from_pretrained(args.model_name_or_path, cache_dir=args.cache_dir)
     else:
         config = config_class()
+
+    args.max_position_embeddings = config.max_position_embeddings
 
     if args.tokenizer_name:
         tokenizer = tokenizer_class.from_pretrained(args.tokenizer_name, cache_dir=args.cache_dir)

--- a/run_train.py
+++ b/run_train.py
@@ -682,9 +682,10 @@ def main():
         "See details at https://nvidia.github.io/apex/amp.html",
     )
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
+    parser.add_argument("--gpu_rank", type=int, default=1, help="Select GPU to train")
     args = parser.parse_args()
 
-    os.environ["CUDA_VISIBLE_DEVICES"]="1"
+    os.environ["CUDA_VISIBLE_DEVICES"]=str(args.gpu_rank)
 
     if args.eval_data_file is None and args.do_eval:
         raise ValueError(

--- a/run_train.py
+++ b/run_train.py
@@ -229,7 +229,7 @@ def train(args, train_dataset, model: PreTrainedModel, tokenizer: PreTrainedToke
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
 
-        model_distr = model.module if isinstance(model, torch.nn.DataParallel) else model  # Take care of distributed/parallel training
+        model_distr = model.module if (args.n_gpu > 1 or args.local_rank != -1) else model  # Take care of distributed/parallel training
 
         guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels
@@ -472,8 +472,8 @@ def evaluate(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, prefi
         langid_tgtsrc = pad_sequence(langid_tgtsrc, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_examples_srctgt = pad_sequence(psi_examples_srctgt, batch_first=True, padding_value=tokenizer.pad_token_id)
         psi_labels = torch.tensor(psi_labels)
-        
-        model_distr = model.module if isinstance(model, torch.nn.DataParallel) else model  # Take care of distributed/parallel training
+
+        model_distr = model.module if (args.n_gpu > 1 or args.local_rank != -1) else model # Take care of distributed/parallel training
 
         guides = model_distr.get_aligned_word(examples_src, examples_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, src_len, tgt_len, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold)
         return examples_src, examples_tgt, guides, examples_srctgt, langid_srctgt, examples_tgtsrc, langid_tgtsrc, psi_examples_srctgt, psi_labels


### PR DESCRIPTION
`run_train.py`: Skip parallel instances that have more than 512 tokens when combined. This is a problem considering the input limit of transformers.
`run_align.py`: In addition to the word indices output file, this module will generate an additional output file with the words.

`run_align.py` now generates two files, args.output_file (alignment shown with word-indices) && args.output_file+".outtxt" (alignment shown with words).